### PR TITLE
Add country flags (and import template tags)

### DIFF
--- a/memopol/templatetags/memopol_tags.py
+++ b/memopol/templatetags/memopol_tags.py
@@ -21,10 +21,6 @@ def fix_url(url):
     return re.sub('^(https?://)?', 'https://', url.strip())
 
 
-def cssify(string):
-    return re.sub('[^a-z_-]', '', string.lower())
-
-
 @register.filter
 def twitter_link(url):
     furl = fix_url(url)

--- a/memopol/templatetags/memopol_tags.py
+++ b/memopol/templatetags/memopol_tags.py
@@ -21,6 +21,10 @@ def fix_url(url):
     return re.sub('^(https?://)?', 'https://', url.strip())
 
 
+def cssify(string):
+    return re.sub('[^a-z_-]', '', string.lower())
+
+
 @register.filter
 def twitter_link(url):
     furl = fix_url(url)

--- a/memopol/tests/response_fixtures/GroupListTest.test_country/content
+++ b/memopol/tests/response_fixtures/GroupListTest.test_country/content
@@ -190,8 +190,7 @@
           <td>
             <a href='/legislature/representative/country/European%20Parliament/Austria/'>
               
-                Austria
-
+                <span class="flag-icon flag-icon-at"></span> Austria
               
             </a>
           </td>
@@ -209,8 +208,7 @@
           <td>
             <a href='/legislature/representative/country/European%20Parliament/Belgium/'>
               
-                Belgium
-
+                <span class="flag-icon flag-icon-be"></span> Belgium
               
             </a>
           </td>
@@ -228,8 +226,7 @@
           <td>
             <a href='/legislature/representative/country/European%20Parliament/Bulgaria/'>
               
-                Bulgaria
-
+                <span class="flag-icon flag-icon-bg"></span> Bulgaria
               
             </a>
           </td>
@@ -247,8 +244,7 @@
           <td>
             <a href='/legislature/representative/country/European%20Parliament/Cyprus/'>
               
-                Cyprus
-
+                <span class="flag-icon flag-icon-cy"></span> Cyprus
               
             </a>
           </td>
@@ -266,8 +262,7 @@
           <td>
             <a href='/legislature/representative/country/European%20Parliament/Czech%20Republic/'>
               
-                Czech Republic
-
+                <span class="flag-icon flag-icon-cz"></span> Czech Republic
               
             </a>
           </td>
@@ -285,8 +280,7 @@
           <td>
             <a href='/legislature/representative/country/European%20Parliament/Denmark/'>
               
-                Denmark
-
+                <span class="flag-icon flag-icon-dk"></span> Denmark
               
             </a>
           </td>
@@ -304,8 +298,7 @@
           <td>
             <a href='/legislature/representative/country/European%20Parliament/Estonia/'>
               
-                Estonia
-
+                <span class="flag-icon flag-icon-ee"></span> Estonia
               
             </a>
           </td>
@@ -323,8 +316,7 @@
           <td>
             <a href='/legislature/representative/country/European%20Parliament/Finland/'>
               
-                Finland
-
+                <span class="flag-icon flag-icon-fi"></span> Finland
               
             </a>
           </td>
@@ -342,8 +334,7 @@
           <td>
             <a href='/legislature/representative/country/European%20Parliament/France/'>
               
-                France
-
+                <span class="flag-icon flag-icon-fr"></span> France
               
             </a>
           </td>
@@ -361,8 +352,7 @@
           <td>
             <a href='/legislature/representative/country/European%20Parliament/Germany/'>
               
-                Germany
-
+                <span class="flag-icon flag-icon-de"></span> Germany
               
             </a>
           </td>
@@ -380,8 +370,7 @@
           <td>
             <a href='/legislature/representative/country/European%20Parliament/Greece/'>
               
-                Greece
-
+                <span class="flag-icon flag-icon-gr"></span> Greece
               
             </a>
           </td>
@@ -399,8 +388,7 @@
           <td>
             <a href='/legislature/representative/country/European%20Parliament/Hungary/'>
               
-                Hungary
-
+                <span class="flag-icon flag-icon-hu"></span> Hungary
               
             </a>
           </td>

--- a/templates/representatives/_representative_block.haml
+++ b/templates/representatives/_representative_block.haml
@@ -1,5 +1,4 @@
 - load memopol_tags
-- load representatives_tags
 - load representatives_recommendations_tags
 - load humanize
 

--- a/templates/representatives/group_list.haml
+++ b/templates/representatives/group_list.haml
@@ -1,7 +1,6 @@
 - extends 'base.html'
 
 - load memopol_tags
-- load representatives_tags
 
 - block content
 
@@ -25,6 +24,8 @@
             %a{'href': "{% group_url group %}"}=
               - if group.kind == 'chamber'
                 = group|chamber_icon
+              - elif group.kind == 'country'
+                = group|country_flag
               - elif group.kind == 'group'
                 = group|group_long_icon
               - else

--- a/templates/representatives/representative_detail.haml
+++ b/templates/representatives/representative_detail.haml
@@ -2,8 +2,6 @@
 
 - load humanize
 - load memopol_tags
-- load representatives_tags
-- load representatives_votes_tags
 - load representatives_recommendations_tags
 
 - block head

--- a/templates/representatives/representative_grid.haml
+++ b/templates/representatives/representative_grid.haml
@@ -1,7 +1,6 @@
 - extends 'representatives/representative_list.html'
 
 - load memopol_tags
-- load representatives_tags
 - load representatives_recommendations_tags
 
 - block list

--- a/templates/representatives/representative_list.haml
+++ b/templates/representatives/representative_list.haml
@@ -2,7 +2,6 @@
 
 - load i18n
 - load memopol_tags
-- load representatives_tags
 - load representatives_recommendations_tags
 
 - block content

--- a/templates/representatives_votes/dossier_detail.haml
+++ b/templates/representatives_votes/dossier_detail.haml
@@ -1,7 +1,7 @@
 - extends "base.html"
 
 - load i18n
-- load representatives_votes_tags
+- load memopol_tags
 
 - block content
 


### PR DESCRIPTION
This PR adds country flags to the Countries page.
It also imports template tags from django-representatives[-votes] so that they can be removed from there later.