### PR TITLE
Switch to pgsql-only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,25 @@
 sudo: false
 env:
-- DJANGO_DEBUG=True DJANGO_SETTINGS_MODULE=memopol.settings
+  global:
+  - DJANGO_DEBUG=True
+  - DJANGO_SETTINGS_MODULE=memopol.settings
+  - MEMOPOL_DB_NAME=memopol
+  - MEMOPOL_DB_USER=memopol
+  - MEMOPOL_DB_PASSWORD=memopol
+  - MEMOPOL_DB_HOST=localhost
+  - MEMOPOL_DB_PORT=5432
+  - MEMOPOL_DB_ENGINE=django.db.backends.postgresql_psycopg2
 language: python
 python:
 - '2.7'
+services:
+- postgresql
 install:
 - pip install -e .[testing]
 before_script:
 - bin/install_client_deps.sh
+- psql -c "CREATE USER memopol WITH CREATEDB PASSWORD 'memopol';" -U postgres
+- psql -c "CREATE DATABASE memopol WITH OWNER memopol;" -U postgres
 script:
 - flake8 . --exclude '*/migrations,docs,static' --ignore E128
 - py.test memopol representatives_positions representatives_recommendations

--- a/bin/quickstart.sh
+++ b/bin/quickstart.sh
@@ -22,6 +22,15 @@ pip install -e .[testing]
 # Install client dependencies
 bin/install_client_deps.sh
 
+# Create pg user and database
+if [ $(psql -c "select 'CNT=' || count(1) from pg_catalog.pg_user where usename='memopol';" -U postgres | grep CNT=1 | wc -l) -lt 1 ]; then
+	psql -c "create user memopol with password 'memopol';" -U postgres
+fi
+psql -c "alter role memopol with createdb;" -U postgres
+if [ $(psql -l -U postgres | egrep "^ memopol\W" | wc -l) -lt 1 ]; then
+	psql -c "create database memopol with owner memopol;" -U postgres
+fi
+
 # Setup environment
 export DJANGO_DEBUG=True
 export DJANGO_SETTINGS_MODULE=memopol.settings

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -101,38 +101,33 @@ the ``DJANGO_DEBUG`` variable in the current shell::
 
     $ export DJANGO_DEBUG=True
 
-Run the development server
-==========================
+Setup the database
+==================
 
-Run the development server::
+Memopol requires PostgreSQL 9.1 or higher.  It used to run with SQLite, too, but
+that is no longer the case.  Memopol uses the following environment variables
+for database access:
 
-    $ ./manage.py runserver
+* ``MEMOPOL_DB_NAME`` (defaults to 'memopol')
+* ``MEMOPOL_DB_USER`` (defaults to 'memopol')
+* ``MEMOPOL_DB_PASSWORD`` (defaults to 'memopol')
+* ``MEMOPOL_DB_HOST`` (defaults to 'localhost')
+* ``MEMOPOL_DB_PORT`` (defaults to '5432')
 
-    Performing system checks...
+Make sure the corresponding user and database exist on your system; the user
+will need the 'createdb' permission in order to be able to run tests.  To create
+them, you may use the following commands:
 
-    System check identified no issues (0 silenced).
-    December 09, 2015 - 21:26:47
-    Django version 1.8.7, using settings 'memopol.settings'
-    Starting development server at http://127.0.0.1:8000/
-    Quit the server with CONTROL-C.
-    [09/Dec/2015 21:26:48] "GET / HTTP/1.1" 200 13294
-
-The website is running on ``http://127.0.0.1:8000/``.
+    $ psql -c "create user memopol with password 'memopol';" -U postgres
+    $ psql -c "alter role memopol with createdb;" -U postgres
+    $ psql -c "create database memopol with owner memopol;" -U postgres
 
 Database migrations
 ===================
 
-The repo comes with a pre-configured SQLite db with sample data so that you can
-start hacking right away. However, if you were to use a local postgresql
-database ie. with this sort of environment::
-
-    export DJANGO_DATABASE_DEFAULT_NAME=memopol
-    export DJANGO_DATABASE_DEFAULT_USER=postgres
-    export DJANGO_DATABASE_DEFAULT_ENGINE=django.db.backends.postgresql_psycopg2
-    export DJANGO_DEBUG=1
-    export DJANGO_SETTINGS_MODULE=memopol.settings
-
-Then you could run database migrations::
+Database migrations ensure the database schema is up to date with the project.
+If you're not sure, you can run them anyway, they won't do any harm.  Use the
+following command::
 
     $ ./manage.py migrate
     Operations to perform:
@@ -153,13 +148,30 @@ Then you could run database migrations::
 Provision with data
 ===================
 
-Again, the repo comes with a pre-configured SQLite db with sample data so that
-you can start hacking right away. However, you could still reload sample data::
+You can load a small data sample for quick setup:
 
     $ ./manage.py loaddata memopol/fixtures/small_sample.json
 
 Or actual data (takes a while)::
 
     $ bin/update_all
+
+Run the development server
+==========================
+
+Run the development server::
+
+    $ ./manage.py runserver
+
+    Performing system checks...
+
+    System check identified no issues (0 silenced).
+    December 09, 2015 - 21:26:47
+    Django version 1.8.7, using settings 'memopol.settings'
+    Starting development server at http://127.0.0.1:8000/
+    Quit the server with CONTROL-C.
+    [09/Dec/2015 21:26:48] "GET / HTTP/1.1" 200 13294
+
+The website is running on ``http://127.0.0.1:8000/``.
 
 Continue to :doc:`administration`.

--- a/memopol/settings.py
+++ b/memopol/settings.py
@@ -125,19 +125,15 @@ WSGI_APPLICATION = 'memopol.wsgi.application'
 
 DATABASES = {
     'default': {
-        'NAME': os.environ.get('DJANGO_DATABASE_DEFAULT_NAME', 'db.sqlite'),
-        'USER': os.environ.get('DJANGO_DATABASE_DEFAULT_USER', ''),
-        'PASSWORD': os.environ.get('DJANGO_DATABASE_DEFAULT_PASSWORD', ''),
-        'HOST': os.environ.get('DJANGO_DATABASE_DEFAULT_HOST', ''),
-        'PORT': os.environ.get('DJANGO_DATABASE_DEFAULT_PORT', ''),
-        'ENGINE': os.environ.get('DJANGO_DATABASE_DEFAULT_ENGINE',
-                                 'django.db.backends.sqlite3'),
-
+        'NAME': os.environ.get('MEMOPOL_DB_NAME', 'memopol'),
+        'USER': os.environ.get('MEMOPOL_DB_USER', 'memopol'),
+        'PASSWORD': os.environ.get('MEMOPOL_DB_PASSWORD', 'memopol'),
+        'HOST': os.environ.get('MEMOPOL_DB_HOST', 'localhost'),
+        'PORT': os.environ.get('MEMOPOL_DB_PORT', '5432'),
+        'ENGINE': os.environ.get('MEMOPOL_DB_ENGINE',
+                                 'django.db.backends.postgresql_psycopg2'),
     }
 }
-
-if 'OPENSHIFT_DATA_DIR' in os.environ:
-    DATABASES['default']['NAME'] = os.path.join(DATA_DIR, 'db.sqlite')
 
 if 'OPENSHIFT_POSTGRESQL_DB_HOST' in os.environ:
     DATABASES['default']['NAME'] = os.environ['OPENSHIFT_APP_NAME']
@@ -147,7 +143,6 @@ if 'OPENSHIFT_POSTGRESQL_DB_HOST' in os.environ:
         'OPENSHIFT_POSTGRESQL_DB_PASSWORD']
     DATABASES['default']['HOST'] = os.environ['OPENSHIFT_POSTGRESQL_DB_HOST']
     DATABASES['default']['PORT'] = os.environ['OPENSHIFT_POSTGRESQL_DB_PORT']
-    DATABASES['default']['ENGINE'] = 'django.db.backends.postgresql_psycopg2'
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.7/topics/i18n/

--- a/memopol/tests/RepresentativeDetailTest/test_mandates_display.html
+++ b/memopol/tests/RepresentativeDetailTest/test_mandates_display.html
@@ -3,49 +3,23 @@
   <table class='table table-condensed mandates'>
 
       <tr class='mandate'>
-        <td>Member</td>
-        <td>
-          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Women&#39;s%20Rights%20and%20Gender%20Equality/'>
-            Committee on Women&#39;s Rights and Gender Equality
-
-              FEMM
-
-          </a>
-        </td>
-        <td>01/07/2014</td>
-        <td>present</td>
-        <td>European Parliament</td>
-
-      </tr>
-
-      <tr class='mandate'>
-        <td>Member</td>
-        <td>
-          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Legal%20Affairs/'>
-            Committee on Legal Affairs
-
-              JURI
-
-          </a>
-        </td>
-        <td>01/07/2014</td>
-        <td>present</td>
-        <td>European Parliament</td>
-
-      </tr>
-
-      <tr class='mandate'>
         <td>Substitute</td>
         <td>
-          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Culture%20and%20Education/'>
-            Committee on Culture and Education
-
-              CULT
+          <a href='/legislature/representative/delegation/European%20Parliament/Delegation%20for%20relations%20with%20Palestine/'>
+            Delegation for relations with Palestine
 
           </a>
         </td>
-        <td>08/07/2014</td>
-        <td>present</td>
+        <td>
+
+            14/07/2014
+
+        </td>
+        <td>
+
+            present
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -58,8 +32,16 @@
 
           </a>
         </td>
-        <td>14/07/2014</td>
-        <td>present</td>
+        <td>
+
+            14/07/2014
+
+        </td>
+        <td>
+
+            present
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -72,8 +54,16 @@
 
           </a>
         </td>
-        <td>14/07/2014</td>
-        <td>present</td>
+        <td>
+
+            14/07/2014
+
+        </td>
+        <td>
+
+            present
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -81,13 +71,23 @@
       <tr class='mandate'>
         <td>Substitute</td>
         <td>
-          <a href='/legislature/representative/delegation/European%20Parliament/Delegation%20for%20relations%20with%20Palestine/'>
-            Delegation for relations with Palestine
+          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Culture%20and%20Education/'>
+            Committee on Culture and Education
+
+              CULT
 
           </a>
         </td>
-        <td>14/07/2014</td>
-        <td>present</td>
+        <td>
+
+            08/07/2014
+
+        </td>
+        <td>
+
+            present
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -95,15 +95,47 @@
       <tr class='mandate'>
         <td>Member</td>
         <td>
-          <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
-            Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
+          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Legal%20Affairs/'>
+            Committee on Legal Affairs
 
-              SD
+              JURI
 
           </a>
         </td>
-        <td>01/07/2014</td>
-        <td>present</td>
+        <td>
+
+            01/07/2014
+
+        </td>
+        <td>
+
+            present
+
+        </td>
+        <td>European Parliament</td>
+
+      </tr>
+
+      <tr class='mandate'>
+        <td>Member</td>
+        <td>
+          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Women&#39;s%20Rights%20and%20Gender%20Equality/'>
+            Committee on Women&#39;s Rights and Gender Equality
+
+              FEMM
+
+          </a>
+        </td>
+        <td>
+
+            01/07/2014
+
+        </td>
+        <td>
+
+            present
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -118,8 +150,16 @@
 
           </a>
         </td>
-        <td>01/07/2014</td>
-        <td>present</td>
+        <td>
+
+            01/07/2014
+
+        </td>
+        <td>
+
+            present
+
+        </td>
         <td>Labour Party</td>
 
       </tr>
@@ -127,15 +167,23 @@
       <tr class='mandate'>
         <td>Member</td>
         <td>
-          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Women&#39;s%20Rights%20and%20Gender%20Equality/'>
-            Committee on Women&#39;s Rights and Gender Equality
+          <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
+            Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 
-              FEMM
+              SD
 
           </a>
         </td>
-        <td>19/01/2012</td>
-        <td>30/06/2014</td>
+        <td>
+
+            01/07/2014
+
+        </td>
+        <td>
+
+            present
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -150,8 +198,16 @@
 
           </a>
         </td>
-        <td>19/01/2012</td>
-        <td>30/06/2014</td>
+        <td>
+
+            19/01/2012
+
+        </td>
+        <td>
+
+            30/06/2014
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -166,8 +222,40 @@
 
           </a>
         </td>
-        <td>19/01/2012</td>
-        <td>30/06/2014</td>
+        <td>
+
+            19/01/2012
+
+        </td>
+        <td>
+
+            30/06/2014
+
+        </td>
+        <td>European Parliament</td>
+
+      </tr>
+
+      <tr class='mandate'>
+        <td>Member</td>
+        <td>
+          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Women&#39;s%20Rights%20and%20Gender%20Equality/'>
+            Committee on Women&#39;s Rights and Gender Equality
+
+              FEMM
+
+          </a>
+        </td>
+        <td>
+
+            19/01/2012
+
+        </td>
+        <td>
+
+            30/06/2014
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -180,24 +268,16 @@
 
           </a>
         </td>
-        <td>16/09/2009</td>
-        <td>30/06/2014</td>
-        <td>European Parliament</td>
-
-      </tr>
-
-      <tr class='mandate'>
-        <td>Member</td>
         <td>
-          <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
-            Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 
-              SD
+            16/09/2009
 
-          </a>
         </td>
-        <td>14/07/2009</td>
-        <td>30/06/2014</td>
+        <td>
+
+            30/06/2014
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -212,8 +292,16 @@
 
           </a>
         </td>
-        <td>14/07/2009</td>
-        <td>30/06/2014</td>
+        <td>
+
+            14/07/2009
+
+        </td>
+        <td>
+
+            30/06/2014
+
+        </td>
         <td>Labour Party</td>
 
       </tr>
@@ -221,31 +309,23 @@
       <tr class='mandate'>
         <td>Member</td>
         <td>
-          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Women&#39;s%20Rights%20and%20Gender%20Equality/'>
-            Committee on Women&#39;s Rights and Gender Equality
+          <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
+            Group of the Progressive Alliance of Socialists and Democrats in the European Parliament
 
-              FEMM
+              SD
 
           </a>
         </td>
-        <td>16/07/2009</td>
-        <td>18/01/2012</td>
-        <td>European Parliament</td>
-
-      </tr>
-
-      <tr class='mandate'>
-        <td>Member</td>
         <td>
-          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Culture%20and%20Education/'>
-            Committee on Culture and Education
 
-              CULT
+            14/07/2009
 
-          </a>
         </td>
-        <td>16/07/2009</td>
-        <td>18/01/2012</td>
+        <td>
+
+            30/06/2014
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -260,8 +340,64 @@
 
           </a>
         </td>
-        <td>20/09/2010</td>
-        <td>18/01/2012</td>
+        <td>
+
+            20/09/2010
+
+        </td>
+        <td>
+
+            18/01/2012
+
+        </td>
+        <td>European Parliament</td>
+
+      </tr>
+
+      <tr class='mandate'>
+        <td>Member</td>
+        <td>
+          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Culture%20and%20Education/'>
+            Committee on Culture and Education
+
+              CULT
+
+          </a>
+        </td>
+        <td>
+
+            16/07/2009
+
+        </td>
+        <td>
+
+            18/01/2012
+
+        </td>
+        <td>European Parliament</td>
+
+      </tr>
+
+      <tr class='mandate'>
+        <td>Member</td>
+        <td>
+          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Women&#39;s%20Rights%20and%20Gender%20Equality/'>
+            Committee on Women&#39;s Rights and Gender Equality
+
+              FEMM
+
+          </a>
+        </td>
+        <td>
+
+            16/07/2009
+
+        </td>
+        <td>
+
+            18/01/2012
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -276,8 +412,40 @@
 
           </a>
         </td>
-        <td>16/07/2009</td>
-        <td>19/09/2010</td>
+        <td>
+
+            16/07/2009
+
+        </td>
+        <td>
+
+            19/09/2010
+
+        </td>
+        <td>European Parliament</td>
+
+      </tr>
+
+      <tr class='mandate'>
+        <td>Substitute</td>
+        <td>
+          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Culture%20and%20Education/'>
+            Committee on Culture and Education
+
+              CULT
+
+          </a>
+        </td>
+        <td>
+
+            31/01/2007
+
+        </td>
+        <td>
+
+            13/07/2009
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -292,24 +460,16 @@
 
           </a>
         </td>
-        <td>31/01/2007</td>
-        <td>13/07/2009</td>
-        <td>European Parliament</td>
-
-      </tr>
-
-      <tr class='mandate'>
-        <td>Substitute</td>
         <td>
-          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Culture%20and%20Education/'>
-            Committee on Culture and Education
 
-              CULT
+            31/01/2007
 
-          </a>
         </td>
-        <td>31/01/2007</td>
-        <td>13/07/2009</td>
+        <td>
+
+            13/07/2009
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -324,8 +484,16 @@
 
           </a>
         </td>
-        <td>31/01/2007</td>
-        <td>13/07/2009</td>
+        <td>
+
+            31/01/2007
+
+        </td>
+        <td>
+
+            13/07/2009
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -338,22 +506,16 @@
 
           </a>
         </td>
-        <td>15/09/2004</td>
-        <td>13/07/2009</td>
-        <td>European Parliament</td>
-
-      </tr>
-
-      <tr class='mandate'>
-        <td>Substitute</td>
         <td>
-          <a href='/legislature/representative/delegation/European%20Parliament/Delegation%20to%20the%20EU-Turkey%20Joint%20Parliamentary%20Committee/'>
-            Delegation to the EU-Turkey Joint Parliamentary Committee
 
-          </a>
+            15/09/2004
+
         </td>
-        <td>15/09/2004</td>
-        <td>13/07/2009</td>
+        <td>
+
+            13/07/2009
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -366,24 +528,38 @@
 
           </a>
         </td>
-        <td>15/09/2004</td>
-        <td>13/07/2009</td>
+        <td>
+
+            15/09/2004
+
+        </td>
+        <td>
+
+            13/07/2009
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
 
       <tr class='mandate'>
-        <td>Member</td>
+        <td>Substitute</td>
         <td>
-          <a href='/legislature/representative/group/European%20Parliament/Socialist%20Group%20in%20the%20European%20Parliament/'>
-            Socialist Group in the European Parliament
-
-              PSE
+          <a href='/legislature/representative/delegation/European%20Parliament/Delegation%20to%20the%20EU-Turkey%20Joint%20Parliamentary%20Committee/'>
+            Delegation to the EU-Turkey Joint Parliamentary Committee
 
           </a>
         </td>
-        <td>20/07/2004</td>
-        <td>13/07/2009</td>
+        <td>
+
+            15/09/2004
+
+        </td>
+        <td>
+
+            13/07/2009
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -398,8 +574,16 @@
 
           </a>
         </td>
-        <td>20/07/2004</td>
-        <td>13/07/2009</td>
+        <td>
+
+            20/07/2004
+
+        </td>
+        <td>
+
+            13/07/2009
+
+        </td>
         <td>Labour Party</td>
 
       </tr>
@@ -407,31 +591,23 @@
       <tr class='mandate'>
         <td>Member</td>
         <td>
-          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20the%20Environment,%20Public%20Health%20and%20Food%20Safety/'>
-            Committee on the Environment, Public Health and Food Safety
+          <a href='/legislature/representative/group/European%20Parliament/Socialist%20Group%20in%20the%20European%20Parliament/'>
+            Socialist Group in the European Parliament
 
-              ENVI
+              PSE
 
           </a>
         </td>
-        <td>15/01/2007</td>
-        <td>30/01/2007</td>
-        <td>European Parliament</td>
-
-      </tr>
-
-      <tr class='mandate'>
-        <td>Substitute</td>
         <td>
-          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Women&#39;s%20Rights%20and%20Gender%20Equality/'>
-            Committee on Women&#39;s Rights and Gender Equality
 
-              FEMM
+            20/07/2004
 
-          </a>
         </td>
-        <td>15/01/2007</td>
-        <td>30/01/2007</td>
+        <td>
+
+            13/07/2009
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -446,8 +622,16 @@
 
           </a>
         </td>
-        <td>15/01/2007</td>
-        <td>30/01/2007</td>
+        <td>
+
+            15/01/2007
+
+        </td>
+        <td>
+
+            30/01/2007
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -462,8 +646,16 @@
 
           </a>
         </td>
-        <td>21/07/2004</td>
-        <td>14/01/2007</td>
+        <td>
+
+            15/01/2007
+
+        </td>
+        <td>
+
+            30/01/2007
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -478,8 +670,16 @@
 
           </a>
         </td>
-        <td>21/07/2004</td>
-        <td>14/01/2007</td>
+        <td>
+
+            15/01/2007
+
+        </td>
+        <td>
+
+            30/01/2007
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -494,8 +694,64 @@
 
           </a>
         </td>
-        <td>21/07/2004</td>
-        <td>14/01/2007</td>
+        <td>
+
+            21/07/2004
+
+        </td>
+        <td>
+
+            14/01/2007
+
+        </td>
+        <td>European Parliament</td>
+
+      </tr>
+
+      <tr class='mandate'>
+        <td>Member</td>
+        <td>
+          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20the%20Environment,%20Public%20Health%20and%20Food%20Safety/'>
+            Committee on the Environment, Public Health and Food Safety
+
+              ENVI
+
+          </a>
+        </td>
+        <td>
+
+            21/07/2004
+
+        </td>
+        <td>
+
+            14/01/2007
+
+        </td>
+        <td>European Parliament</td>
+
+      </tr>
+
+      <tr class='mandate'>
+        <td>Substitute</td>
+        <td>
+          <a href='/legislature/representative/committee/European%20Parliament/Committee%20on%20Women&#39;s%20Rights%20and%20Gender%20Equality/'>
+            Committee on Women&#39;s Rights and Gender Equality
+
+              FEMM
+
+          </a>
+        </td>
+        <td>
+
+            21/07/2004
+
+        </td>
+        <td>
+
+            14/01/2007
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -510,24 +766,16 @@
 
           </a>
         </td>
-        <td>17/01/2002</td>
-        <td>19/07/2004</td>
-        <td>European Parliament</td>
-
-      </tr>
-
-      <tr class='mandate'>
-        <td>Member</td>
         <td>
-          <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Party%20of%20European%20Socialists/'>
-            Group of the Party of European Socialists
 
-              PSE
+            17/01/2002
 
-          </a>
         </td>
-        <td>17/02/2000</td>
-        <td>19/07/2004</td>
+        <td>
+
+            19/07/2004
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -542,9 +790,41 @@
 
           </a>
         </td>
-        <td>17/02/2000</td>
-        <td>19/07/2004</td>
+        <td>
+
+            17/02/2000
+
+        </td>
+        <td>
+
+            19/07/2004
+
+        </td>
         <td>Labour Party</td>
+
+      </tr>
+
+      <tr class='mandate'>
+        <td>Member</td>
+        <td>
+          <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Party%20of%20European%20Socialists/'>
+            Group of the Party of European Socialists
+
+              PSE
+
+          </a>
+        </td>
+        <td>
+
+            17/02/2000
+
+        </td>
+        <td>
+
+            19/07/2004
+
+        </td>
+        <td>European Parliament</td>
 
       </tr>
 
@@ -556,8 +836,16 @@
 
           </a>
         </td>
-        <td>07/02/2002</td>
-        <td>30/04/2004</td>
+        <td>
+
+            07/02/2002
+
+        </td>
+        <td>
+
+            30/04/2004
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -570,8 +858,38 @@
 
           </a>
         </td>
-        <td>07/02/2002</td>
-        <td>30/04/2004</td>
+        <td>
+
+            07/02/2002
+
+        </td>
+        <td>
+
+            30/04/2004
+
+        </td>
+        <td>European Parliament</td>
+
+      </tr>
+
+      <tr class='mandate'>
+        <td>Member</td>
+        <td>
+          <a href='/legislature/representative/delegation/European%20Parliament/Delegation%20to%20the%20EU-Cyprus%20Joint%20Parliamentary%20Committee/'>
+            Delegation to the EU-Cyprus Joint Parliamentary Committee
+
+          </a>
+        </td>
+        <td>
+
+            11/04/2000
+
+        </td>
+        <td>
+
+            14/01/2002
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
@@ -586,25 +904,18 @@
 
           </a>
         </td>
-        <td>01/03/2000</td>
-        <td>14/01/2002</td>
-        <td>European Parliament</td>
-
-      </tr>
-
-      <tr class='mandate'>
-        <td>Member</td>
         <td>
-          <a href='/legislature/representative/delegation/European%20Parliament/Delegation%20to%20the%20EU-Cyprus%20Joint%20Parliamentary%20Committee/'>
-            Delegation to the EU-Cyprus Joint Parliamentary Committee
 
-          </a>
+            01/03/2000
+
         </td>
-        <td>11/04/2000</td>
-        <td>14/01/2002</td>
+        <td>
+
+            14/01/2002
+
+        </td>
         <td>European Parliament</td>
 
       </tr>
 
   </table>
-

--- a/memopol/tests/response_fixtures/GroupListTest.test_active_parties.content
+++ b/memopol/tests/response_fixtures/GroupListTest.test_active_parties.content
@@ -238,41 +238,16 @@
             </td>
           
           <td>
-            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Freedom%20and%20Direct%20Democracy%20Group/'>
+            <a href='/legislature/representative/group/European%20Parliament/European%20Conservatives%20and%20Reformists%20Group/'>
               
-                EFDD
-              
-            </a>
-          </td>
-          <td>
-            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Freedom%20and%20Direct%20Democracy%20Group/'>
-              
-                <span class="group-icon group-icon-efdd"></span> Europe of Freedom and Direct Democracy Group
-              
-            </a>
-          </td>
-        </tr>
-      
-        <tr>
-          
-            <td>
-              <a href='/legislature/representative/chamber/European%20Parliament/'>
-                <span class="chamber-icon chamber-icon-ep"></span> European Parliament
-
-              </a>
-            </td>
-          
-          <td>
-            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Nations%20and%20Freedom%20Group/'>
-              
-                ENF
+                ECR
               
             </a>
           </td>
           <td>
-            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Nations%20and%20Freedom%20Group/'>
+            <a href='/legislature/representative/group/European%20Parliament/European%20Conservatives%20and%20Reformists%20Group/'>
               
-                <span class="group-icon group-icon-enf"></span> Europe of Nations and Freedom Group
+                <span class="group-icon group-icon-ecr"></span> European Conservatives and Reformists Group
               
             </a>
           </td>
@@ -313,16 +288,16 @@
             </td>
           
           <td>
-            <a href='/legislature/representative/group/European%20Parliament/European%20Conservatives%20and%20Reformists%20Group/'>
+            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Freedom%20and%20Direct%20Democracy%20Group/'>
               
-                ECR
+                EFDD
               
             </a>
           </td>
           <td>
-            <a href='/legislature/representative/group/European%20Parliament/European%20Conservatives%20and%20Reformists%20Group/'>
+            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Freedom%20and%20Direct%20Democracy%20Group/'>
               
-                <span class="group-icon group-icon-ecr"></span> European Conservatives and Reformists Group
+                <span class="group-icon group-icon-efdd"></span> Europe of Freedom and Direct Democracy Group
               
             </a>
           </td>
@@ -338,16 +313,16 @@
             </td>
           
           <td>
-            <a href='/legislature/representative/group/European%20Parliament/Group%20Union%20for%20Europe/'>
+            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Nations%20and%20Freedom%20Group/'>
               
-                UFE
+                ENF
               
             </a>
           </td>
           <td>
-            <a href='/legislature/representative/group/European%20Parliament/Group%20Union%20for%20Europe/'>
+            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Nations%20and%20Freedom%20Group/'>
               
-                <span class="group-icon group-icon-ufe"></span> Group Union for Europe
+                <span class="group-icon group-icon-enf"></span> Europe of Nations and Freedom Group
               
             </a>
           </td>
@@ -473,6 +448,31 @@
             <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20European%20People&#39;s%20Party%20(Christian%20Democrats)/'>
               
                 <span class="group-icon group-icon-epp"></span> Group of the European People's Party (Christian Democrats)
+              
+            </a>
+          </td>
+        </tr>
+      
+        <tr>
+          
+            <td>
+              <a href='/legislature/representative/chamber/European%20Parliament/'>
+                <span class="chamber-icon chamber-icon-ep"></span> European Parliament
+
+              </a>
+            </td>
+          
+          <td>
+            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20European%20Radical%20Alliance/'>
+              
+                ERA
+              
+            </a>
+          </td>
+          <td>
+            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20European%20Radical%20Alliance/'>
+              
+                <span class="group-icon group-icon-era"></span> Group of the European Radical Alliance
               
             </a>
           </td>

--- a/memopol/tests/response_fixtures/GroupListTest.test_all_parties.content
+++ b/memopol/tests/response_fixtures/GroupListTest.test_all_parties.content
@@ -274,41 +274,16 @@
             </td>
           
           <td>
-            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Freedom%20and%20Direct%20Democracy%20Group/'>
+            <a href='/legislature/representative/group/European%20Parliament/European%20Conservatives%20and%20Reformists%20Group/'>
               
-                EFDD
-              
-            </a>
-          </td>
-          <td>
-            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Freedom%20and%20Direct%20Democracy%20Group/'>
-              
-                <span class="group-icon group-icon-efdd"></span> Europe of Freedom and Direct Democracy Group
-              
-            </a>
-          </td>
-        </tr>
-      
-        <tr>
-          
-            <td>
-              <a href='/legislature/representative/chamber/European%20Parliament/'>
-                <span class="chamber-icon chamber-icon-ep"></span> European Parliament
-
-              </a>
-            </td>
-          
-          <td>
-            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Nations%20and%20Freedom%20Group/'>
-              
-                ENF
+                ECR
               
             </a>
           </td>
           <td>
-            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Nations%20and%20Freedom%20Group/'>
+            <a href='/legislature/representative/group/European%20Parliament/European%20Conservatives%20and%20Reformists%20Group/'>
               
-                <span class="group-icon group-icon-enf"></span> Europe of Nations and Freedom Group
+                <span class="group-icon group-icon-ecr"></span> European Conservatives and Reformists Group
               
             </a>
           </td>
@@ -349,16 +324,16 @@
             </td>
           
           <td>
-            <a href='/legislature/representative/group/European%20Parliament/European%20Conservatives%20and%20Reformists%20Group/'>
+            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Freedom%20and%20Direct%20Democracy%20Group/'>
               
-                ECR
+                EFDD
               
             </a>
           </td>
           <td>
-            <a href='/legislature/representative/group/European%20Parliament/European%20Conservatives%20and%20Reformists%20Group/'>
+            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Freedom%20and%20Direct%20Democracy%20Group/'>
               
-                <span class="group-icon group-icon-ecr"></span> European Conservatives and Reformists Group
+                <span class="group-icon group-icon-efdd"></span> Europe of Freedom and Direct Democracy Group
               
             </a>
           </td>
@@ -374,16 +349,16 @@
             </td>
           
           <td>
-            <a href='/legislature/representative/group/European%20Parliament/Group%20Union%20for%20Europe/'>
+            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Nations%20and%20Freedom%20Group/'>
               
-                UFE
+                ENF
               
             </a>
           </td>
           <td>
-            <a href='/legislature/representative/group/European%20Parliament/Group%20Union%20for%20Europe/'>
+            <a href='/legislature/representative/group/European%20Parliament/Europe%20of%20Nations%20and%20Freedom%20Group/'>
               
-                <span class="group-icon group-icon-ufe"></span> Group Union for Europe
+                <span class="group-icon group-icon-enf"></span> Europe of Nations and Freedom Group
               
             </a>
           </td>
@@ -484,6 +459,31 @@
             <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20European%20Democratic%20Alliance/'>
               
                 <span class="group-icon group-icon-eda"></span> Group of the European Democratic Alliance
+              
+            </a>
+          </td>
+        </tr>
+      
+        <tr>
+          
+            <td>
+              <a href='/legislature/representative/chamber/European%20Parliament/'>
+                <span class="chamber-icon chamber-icon-ep"></span> European Parliament
+
+              </a>
+            </td>
+          
+          <td>
+            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20European%20Liberal,%20Democrat%20and%20Reform%20Party/'>
+              
+                ELDR
+              
+            </a>
+          </td>
+          <td>
+            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20European%20Liberal,%20Democrat%20and%20Reform%20Party/'>
+              
+                <span class="group-icon group-icon-eldr"></span> Group of the European Liberal, Democrat and Reform Party
               
             </a>
           </td>

--- a/memopol/tests/response_fixtures/RepresentativeListTest.test_filter_chamber.content
+++ b/memopol/tests/response_fixtures/RepresentativeListTest.test_filter_chamber.content
@@ -553,6 +553,40 @@
     
       <div class='representative_item active'>
         <p class='photo'>
+          <a href='/legislature/representative/viorica-dancila/'>
+            <img src='http://www.europarl.europa.eu/mepphoto/95281.jpg' width='80' />
+          </a>
+        </p>
+        <ul>
+          <li class='name'>
+            <a href='/legislature/representative/viorica-dancila/'>
+              Viorica DĂNCILĂ
+            </a>
+          </li>
+          <li class='chamber'>
+            <a href='/legislature/representative/chamber/European%20Parliament/'>
+              <span class="chamber-icon chamber-icon-ep"></span> European Parliament
+            </a>
+          </li>
+          <li class='country'>
+            <a href='/legislature/representative/country/Romania/'>
+              <span class="flag-icon flag-icon-ro"></span> Romania
+            </a>
+          </li>
+          <li class='mandate'>
+            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
+              <span class="group-icon group-icon-sd"></span> SD
+            </a>
+          </li>
+          <li class='score'>
+            <span class="label label-success">15</span>
+
+          </li>
+        </ul>
+      </div>
+    
+      <div class='representative_item active'>
+        <p class='photo'>
           <a href='/legislature/representative/michel-dantin/'>
             <img src='http://www.europarl.europa.eu/mepphoto/97296.jpg' width='80' />
           </a>
@@ -614,40 +648,6 @@
           </li>
           <li class='score'>
             <span class="label label-danger">-15</span>
-
-          </li>
-        </ul>
-      </div>
-    
-      <div class='representative_item active'>
-        <p class='photo'>
-          <a href='/legislature/representative/viorica-dancila/'>
-            <img src='http://www.europarl.europa.eu/mepphoto/95281.jpg' width='80' />
-          </a>
-        </p>
-        <ul>
-          <li class='name'>
-            <a href='/legislature/representative/viorica-dancila/'>
-              Viorica DĂNCILĂ
-            </a>
-          </li>
-          <li class='chamber'>
-            <a href='/legislature/representative/chamber/European%20Parliament/'>
-              <span class="chamber-icon chamber-icon-ep"></span> European Parliament
-            </a>
-          </li>
-          <li class='country'>
-            <a href='/legislature/representative/country/Romania/'>
-              <span class="flag-icon flag-icon-ro"></span> Romania
-            </a>
-          </li>
-          <li class='mandate'>
-            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
-              <span class="group-icon group-icon-sd"></span> SD
-            </a>
-          </li>
-          <li class='score'>
-            <span class="label label-success">15</span>
 
           </li>
         </ul>

--- a/memopol/tests/response_fixtures/RepresentativeListTest.test_page1_paginateby12_active_displaylist.content
+++ b/memopol/tests/response_fixtures/RepresentativeListTest.test_page1_paginateby12_active_displaylist.content
@@ -590,6 +590,42 @@
         
           <tr class='representative_item active'>
             <td class='photo'>
+              <a href='/legislature/representative/viorica-dancila/'>
+                <img src='http://www.europarl.europa.eu/mepphoto/95281.jpg' width='80' />
+
+              </a>
+            </td>
+            <td>
+              <a href='/legislature/representative/viorica-dancila/'>
+                Viorica DĂNCILĂ
+
+              </a>
+            </td>
+            <td>
+              <a href='/legislature/representative/chamber/European%20Parliament/'>
+                European Parliament [EP]
+
+              </a>
+            </td>
+            <td>
+              <a href='/legislature/representative/country/Romania/'>
+                Romania [RO]
+
+              </a>
+            </td>
+            <td>
+              <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
+                <span class="group-icon group-icon-sd"></span> SD
+              </a>
+            </td>
+            <td>
+              <span class="label label-success">15</span>
+
+            </td>
+          </tr>
+        
+          <tr class='representative_item active'>
+            <td class='photo'>
               <a href='/legislature/representative/michel-dantin/'>
                 <img src='http://www.europarl.europa.eu/mepphoto/97296.jpg' width='80' />
 
@@ -656,42 +692,6 @@
             </td>
             <td>
               <span class="label label-danger">-15</span>
-
-            </td>
-          </tr>
-        
-          <tr class='representative_item active'>
-            <td class='photo'>
-              <a href='/legislature/representative/viorica-dancila/'>
-                <img src='http://www.europarl.europa.eu/mepphoto/95281.jpg' width='80' />
-
-              </a>
-            </td>
-            <td>
-              <a href='/legislature/representative/viorica-dancila/'>
-                Viorica DĂNCILĂ
-
-              </a>
-            </td>
-            <td>
-              <a href='/legislature/representative/chamber/European%20Parliament/'>
-                European Parliament [EP]
-
-              </a>
-            </td>
-            <td>
-              <a href='/legislature/representative/country/Romania/'>
-                Romania [RO]
-
-              </a>
-            </td>
-            <td>
-              <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
-                <span class="group-icon group-icon-sd"></span> SD
-              </a>
-            </td>
-            <td>
-              <span class="label label-success">15</span>
 
             </td>
           </tr>

--- a/memopol/tests/response_fixtures/RepresentativeListTest.test_page1_paginateby12_all_displaylist.content
+++ b/memopol/tests/response_fixtures/RepresentativeListTest.test_page1_paginateby12_all_displaylist.content
@@ -590,6 +590,42 @@
         
           <tr class='representative_item active'>
             <td class='photo'>
+              <a href='/legislature/representative/viorica-dancila/'>
+                <img src='http://www.europarl.europa.eu/mepphoto/95281.jpg' width='80' />
+
+              </a>
+            </td>
+            <td>
+              <a href='/legislature/representative/viorica-dancila/'>
+                Viorica DĂNCILĂ
+
+              </a>
+            </td>
+            <td>
+              <a href='/legislature/representative/chamber/European%20Parliament/'>
+                European Parliament [EP]
+
+              </a>
+            </td>
+            <td>
+              <a href='/legislature/representative/country/Romania/'>
+                Romania [RO]
+
+              </a>
+            </td>
+            <td>
+              <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
+                <span class="group-icon group-icon-sd"></span> SD
+              </a>
+            </td>
+            <td>
+              <span class="label label-success">15</span>
+
+            </td>
+          </tr>
+        
+          <tr class='representative_item active'>
+            <td class='photo'>
               <a href='/legislature/representative/michel-dantin/'>
                 <img src='http://www.europarl.europa.eu/mepphoto/97296.jpg' width='80' />
 
@@ -656,42 +692,6 @@
             </td>
             <td>
               <span class="label label-danger">-15</span>
-
-            </td>
-          </tr>
-        
-          <tr class='representative_item active'>
-            <td class='photo'>
-              <a href='/legislature/representative/viorica-dancila/'>
-                <img src='http://www.europarl.europa.eu/mepphoto/95281.jpg' width='80' />
-
-              </a>
-            </td>
-            <td>
-              <a href='/legislature/representative/viorica-dancila/'>
-                Viorica DĂNCILĂ
-
-              </a>
-            </td>
-            <td>
-              <a href='/legislature/representative/chamber/European%20Parliament/'>
-                European Parliament [EP]
-
-              </a>
-            </td>
-            <td>
-              <a href='/legislature/representative/country/Romania/'>
-                Romania [RO]
-
-              </a>
-            </td>
-            <td>
-              <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
-                <span class="group-icon group-icon-sd"></span> SD
-              </a>
-            </td>
-            <td>
-              <span class="label label-success">15</span>
 
             </td>
           </tr>

--- a/memopol/tests/response_fixtures/RepresentativeListTest.test_page1_paginateby24_active_displaygrid.content
+++ b/memopol/tests/response_fixtures/RepresentativeListTest.test_page1_paginateby24_active_displaygrid.content
@@ -542,6 +542,40 @@
     
       <div class='representative_item active'>
         <p class='photo'>
+          <a href='/legislature/representative/viorica-dancila/'>
+            <img src='http://www.europarl.europa.eu/mepphoto/95281.jpg' width='80' />
+          </a>
+        </p>
+        <ul>
+          <li class='name'>
+            <a href='/legislature/representative/viorica-dancila/'>
+              Viorica DĂNCILĂ
+            </a>
+          </li>
+          <li class='chamber'>
+            <a href='/legislature/representative/chamber/European%20Parliament/'>
+              <span class="chamber-icon chamber-icon-ep"></span> European Parliament
+            </a>
+          </li>
+          <li class='country'>
+            <a href='/legislature/representative/country/Romania/'>
+              <span class="flag-icon flag-icon-ro"></span> Romania
+            </a>
+          </li>
+          <li class='mandate'>
+            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
+              <span class="group-icon group-icon-sd"></span> SD
+            </a>
+          </li>
+          <li class='score'>
+            <span class="label label-success">15</span>
+
+          </li>
+        </ul>
+      </div>
+    
+      <div class='representative_item active'>
+        <p class='photo'>
           <a href='/legislature/representative/michel-dantin/'>
             <img src='http://www.europarl.europa.eu/mepphoto/97296.jpg' width='80' />
           </a>
@@ -603,40 +637,6 @@
           </li>
           <li class='score'>
             <span class="label label-danger">-15</span>
-
-          </li>
-        </ul>
-      </div>
-    
-      <div class='representative_item active'>
-        <p class='photo'>
-          <a href='/legislature/representative/viorica-dancila/'>
-            <img src='http://www.europarl.europa.eu/mepphoto/95281.jpg' width='80' />
-          </a>
-        </p>
-        <ul>
-          <li class='name'>
-            <a href='/legislature/representative/viorica-dancila/'>
-              Viorica DĂNCILĂ
-            </a>
-          </li>
-          <li class='chamber'>
-            <a href='/legislature/representative/chamber/European%20Parliament/'>
-              <span class="chamber-icon chamber-icon-ep"></span> European Parliament
-            </a>
-          </li>
-          <li class='country'>
-            <a href='/legislature/representative/country/Romania/'>
-              <span class="flag-icon flag-icon-ro"></span> Romania
-            </a>
-          </li>
-          <li class='mandate'>
-            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
-              <span class="group-icon group-icon-sd"></span> SD
-            </a>
-          </li>
-          <li class='score'>
-            <span class="label label-success">15</span>
 
           </li>
         </ul>
@@ -814,40 +814,6 @@
     
       <div class='representative_item active'>
         <p class='photo'>
-          <a href='/legislature/representative/eider-gardiazabal-rubial/'>
-            <img src='http://www.europarl.europa.eu/mepphoto/96991.jpg' width='80' />
-          </a>
-        </p>
-        <ul>
-          <li class='name'>
-            <a href='/legislature/representative/eider-gardiazabal-rubial/'>
-              Eider GARDIAZABAL RUBIAL
-            </a>
-          </li>
-          <li class='chamber'>
-            <a href='/legislature/representative/chamber/European%20Parliament/'>
-              <span class="chamber-icon chamber-icon-ep"></span> European Parliament
-            </a>
-          </li>
-          <li class='country'>
-            <a href='/legislature/representative/country/Spain/'>
-              <span class="flag-icon flag-icon-es"></span> Spain
-            </a>
-          </li>
-          <li class='mandate'>
-            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
-              <span class="group-icon group-icon-sd"></span> SD
-            </a>
-          </li>
-          <li class='score'>
-            <span class="label label-success">15</span>
-
-          </li>
-        </ul>
-      </div>
-    
-      <div class='representative_item active'>
-        <p class='photo'>
           <a href='/legislature/representative/kinga-gal/'>
             <img src='http://www.europarl.europa.eu/mepphoto/28150.jpg' width='80' />
           </a>
@@ -909,6 +875,40 @@
           </li>
           <li class='score'>
             <span class="label label-danger">-15</span>
+
+          </li>
+        </ul>
+      </div>
+    
+      <div class='representative_item active'>
+        <p class='photo'>
+          <a href='/legislature/representative/eider-gardiazabal-rubial/'>
+            <img src='http://www.europarl.europa.eu/mepphoto/96991.jpg' width='80' />
+          </a>
+        </p>
+        <ul>
+          <li class='name'>
+            <a href='/legislature/representative/eider-gardiazabal-rubial/'>
+              Eider GARDIAZABAL RUBIAL
+            </a>
+          </li>
+          <li class='chamber'>
+            <a href='/legislature/representative/chamber/European%20Parliament/'>
+              <span class="chamber-icon chamber-icon-ep"></span> European Parliament
+            </a>
+          </li>
+          <li class='country'>
+            <a href='/legislature/representative/country/Spain/'>
+              <span class="flag-icon flag-icon-es"></span> Spain
+            </a>
+          </li>
+          <li class='mandate'>
+            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
+              <span class="group-icon group-icon-sd"></span> SD
+            </a>
+          </li>
+          <li class='score'>
+            <span class="label label-success">15</span>
 
           </li>
         </ul>

--- a/memopol/tests/response_fixtures/RepresentativeListTest.test_page1_paginateby24_all_displaygrid.content
+++ b/memopol/tests/response_fixtures/RepresentativeListTest.test_page1_paginateby24_all_displaygrid.content
@@ -542,6 +542,40 @@
     
       <div class='representative_item active'>
         <p class='photo'>
+          <a href='/legislature/representative/viorica-dancila/'>
+            <img src='http://www.europarl.europa.eu/mepphoto/95281.jpg' width='80' />
+          </a>
+        </p>
+        <ul>
+          <li class='name'>
+            <a href='/legislature/representative/viorica-dancila/'>
+              Viorica DĂNCILĂ
+            </a>
+          </li>
+          <li class='chamber'>
+            <a href='/legislature/representative/chamber/European%20Parliament/'>
+              <span class="chamber-icon chamber-icon-ep"></span> European Parliament
+            </a>
+          </li>
+          <li class='country'>
+            <a href='/legislature/representative/country/Romania/'>
+              <span class="flag-icon flag-icon-ro"></span> Romania
+            </a>
+          </li>
+          <li class='mandate'>
+            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
+              <span class="group-icon group-icon-sd"></span> SD
+            </a>
+          </li>
+          <li class='score'>
+            <span class="label label-success">15</span>
+
+          </li>
+        </ul>
+      </div>
+    
+      <div class='representative_item active'>
+        <p class='photo'>
           <a href='/legislature/representative/michel-dantin/'>
             <img src='http://www.europarl.europa.eu/mepphoto/97296.jpg' width='80' />
           </a>
@@ -603,40 +637,6 @@
           </li>
           <li class='score'>
             <span class="label label-danger">-15</span>
-
-          </li>
-        </ul>
-      </div>
-    
-      <div class='representative_item active'>
-        <p class='photo'>
-          <a href='/legislature/representative/viorica-dancila/'>
-            <img src='http://www.europarl.europa.eu/mepphoto/95281.jpg' width='80' />
-          </a>
-        </p>
-        <ul>
-          <li class='name'>
-            <a href='/legislature/representative/viorica-dancila/'>
-              Viorica DĂNCILĂ
-            </a>
-          </li>
-          <li class='chamber'>
-            <a href='/legislature/representative/chamber/European%20Parliament/'>
-              <span class="chamber-icon chamber-icon-ep"></span> European Parliament
-            </a>
-          </li>
-          <li class='country'>
-            <a href='/legislature/representative/country/Romania/'>
-              <span class="flag-icon flag-icon-ro"></span> Romania
-            </a>
-          </li>
-          <li class='mandate'>
-            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
-              <span class="group-icon group-icon-sd"></span> SD
-            </a>
-          </li>
-          <li class='score'>
-            <span class="label label-success">15</span>
 
           </li>
         </ul>
@@ -814,40 +814,6 @@
     
       <div class='representative_item active'>
         <p class='photo'>
-          <a href='/legislature/representative/eider-gardiazabal-rubial/'>
-            <img src='http://www.europarl.europa.eu/mepphoto/96991.jpg' width='80' />
-          </a>
-        </p>
-        <ul>
-          <li class='name'>
-            <a href='/legislature/representative/eider-gardiazabal-rubial/'>
-              Eider GARDIAZABAL RUBIAL
-            </a>
-          </li>
-          <li class='chamber'>
-            <a href='/legislature/representative/chamber/European%20Parliament/'>
-              <span class="chamber-icon chamber-icon-ep"></span> European Parliament
-            </a>
-          </li>
-          <li class='country'>
-            <a href='/legislature/representative/country/Spain/'>
-              <span class="flag-icon flag-icon-es"></span> Spain
-            </a>
-          </li>
-          <li class='mandate'>
-            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
-              <span class="group-icon group-icon-sd"></span> SD
-            </a>
-          </li>
-          <li class='score'>
-            <span class="label label-success">15</span>
-
-          </li>
-        </ul>
-      </div>
-    
-      <div class='representative_item active'>
-        <p class='photo'>
           <a href='/legislature/representative/kinga-gal/'>
             <img src='http://www.europarl.europa.eu/mepphoto/28150.jpg' width='80' />
           </a>
@@ -909,6 +875,40 @@
           </li>
           <li class='score'>
             <span class="label label-danger">-15</span>
+
+          </li>
+        </ul>
+      </div>
+    
+      <div class='representative_item active'>
+        <p class='photo'>
+          <a href='/legislature/representative/eider-gardiazabal-rubial/'>
+            <img src='http://www.europarl.europa.eu/mepphoto/96991.jpg' width='80' />
+          </a>
+        </p>
+        <ul>
+          <li class='name'>
+            <a href='/legislature/representative/eider-gardiazabal-rubial/'>
+              Eider GARDIAZABAL RUBIAL
+            </a>
+          </li>
+          <li class='chamber'>
+            <a href='/legislature/representative/chamber/European%20Parliament/'>
+              <span class="chamber-icon chamber-icon-ep"></span> European Parliament
+            </a>
+          </li>
+          <li class='country'>
+            <a href='/legislature/representative/country/Spain/'>
+              <span class="flag-icon flag-icon-es"></span> Spain
+            </a>
+          </li>
+          <li class='mandate'>
+            <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
+              <span class="group-icon group-icon-sd"></span> SD
+            </a>
+          </li>
+          <li class='score'>
+            <span class="label label-success">15</span>
 
           </li>
         </ul>

--- a/memopol/tests/response_fixtures/RepresentativeListTest.test_page2_paginateby12_displaylist.content
+++ b/memopol/tests/response_fixtures/RepresentativeListTest.test_page2_paginateby12_displaylist.content
@@ -459,42 +459,6 @@
         
           <tr class='representative_item active'>
             <td class='photo'>
-              <a href='/legislature/representative/eider-gardiazabal-rubial/'>
-                <img src='http://www.europarl.europa.eu/mepphoto/96991.jpg' width='80' />
-
-              </a>
-            </td>
-            <td>
-              <a href='/legislature/representative/eider-gardiazabal-rubial/'>
-                Eider GARDIAZABAL RUBIAL
-
-              </a>
-            </td>
-            <td>
-              <a href='/legislature/representative/chamber/European%20Parliament/'>
-                European Parliament [EP]
-
-              </a>
-            </td>
-            <td>
-              <a href='/legislature/representative/country/Spain/'>
-                Spain [ES]
-
-              </a>
-            </td>
-            <td>
-              <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
-                <span class="group-icon group-icon-sd"></span> SD
-              </a>
-            </td>
-            <td>
-              <span class="label label-success">15</span>
-
-            </td>
-          </tr>
-        
-          <tr class='representative_item active'>
-            <td class='photo'>
               <a href='/legislature/representative/kinga-gal/'>
                 <img src='http://www.europarl.europa.eu/mepphoto/28150.jpg' width='80' />
 
@@ -561,6 +525,42 @@
             </td>
             <td>
               <span class="label label-danger">-15</span>
+
+            </td>
+          </tr>
+        
+          <tr class='representative_item active'>
+            <td class='photo'>
+              <a href='/legislature/representative/eider-gardiazabal-rubial/'>
+                <img src='http://www.europarl.europa.eu/mepphoto/96991.jpg' width='80' />
+
+              </a>
+            </td>
+            <td>
+              <a href='/legislature/representative/eider-gardiazabal-rubial/'>
+                Eider GARDIAZABAL RUBIAL
+
+              </a>
+            </td>
+            <td>
+              <a href='/legislature/representative/chamber/European%20Parliament/'>
+                European Parliament [EP]
+
+              </a>
+            </td>
+            <td>
+              <a href='/legislature/representative/country/Spain/'>
+                Spain [ES]
+
+              </a>
+            </td>
+            <td>
+              <a href='/legislature/representative/group/European%20Parliament/Group%20of%20the%20Progressive%20Alliance%20of%20Socialists%20and%20Democrats%20in%20the%20European%20Parliament/'>
+                <span class="group-icon group-icon-sd"></span> SD
+              </a>
+            </td>
+            <td>
+              <span class="label label-success">15</span>
 
             </td>
           </tr>

--- a/memopol/views/representative_detail.py
+++ b/memopol/views/representative_detail.py
@@ -59,8 +59,9 @@ class RepresentativeDetail(RepresentativeViewMixin, generic.DetailView):
 
         c['votes'] = c['object'].votes.all()
         c['mandates'] = c['object'].mandates.all()
-        c['positions'] = c['object'].positions.filter(
-            published=True).prefetch_related('tags')
+        c['positions'] = c['object'].positions.filter(published=True) \
+            .prefetch_related('tags') \
+            .order_by('-datetime', 'pk')
 
         c['position_form'] = PositionForm(
             initial={'representative': self.object.pk})

--- a/memopol/views/representative_mixin.py
+++ b/memopol/views/representative_mixin.py
@@ -20,9 +20,9 @@ class RepresentativeViewMixin(object):
         """
         Prefetch Mandates with their Group and Constituency with Country.
         """
-        mandates = Mandate.objects.order_by(
-            '-end_date').select_related('constituency__country', 'group',
-            'group__chamber')
+        mandates = Mandate.objects.order_by('-end_date', '-begin_date',
+            'group__kind', 'group__name').select_related('group',
+            'group__chamber', 'constituency__country')
         return queryset.prefetch_related(
             models.Prefetch('mandates', queryset=mandates))
 

--- a/representatives_positions/tests/test_functional.py
+++ b/representatives_positions/tests/test_functional.py
@@ -34,7 +34,8 @@ class PositionTest(TestCase):
         assert response['Location'] == expected
 
         result = Position.objects.get(text='%stext' % self.id())
-        assert list(result.tags.values_list('name', flat=True)) == self.tags
+        assert list(result.tags.order_by('pk').values_list('name',
+            flat=True)) == self.tags
         assert result.datetime == datetime.date(2015, 12, 11)
         assert result.link == self.fixture['link']
         assert result.representative.pk == self.mep.pk

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(name='political-memory',
         'pytz',  # Always use up-to-date TZ data
         'django-suit>=0.2,<0.3',
         'sqlparse>=0.1,<0.2',
+        'psycopg2>=2,<3',
     ],
     extras_require={
         # Full version hardcode for testing dependencies so that


### PR DESCRIPTION
This PR switches the project to PostgreSQL only. This is necessary for future updates.
Some views and tests have been fixed to not rely on default database ordering (hence the fixture changes).